### PR TITLE
Add full run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,23 @@
 
 Camel K lets you build and deploy your API on Kubernetes or Red Hat OpenShift in less than a second. 
 
-### Run command
+### Run on Minishift
 ```sh
+oc login -u system:admin
+kamel install --cluster-setup
+
+oc login -u developer -p x
+oc new-project demo
+kamel install
+
 kamel run customer-api.xml \
     --open-api customer-api.json \
     --name customers \
     --dependency camel-undertow \
     --dependency camel-rest \
-    --property camel.rest.port=8080 \
-    --dev
+    --property camel.rest.port=8080 
+
+curl http://customers-demo.$(minishift ip).nip.io/camel/customer
 ```
 
 ### Read the tutorial at: 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Camel K lets you build and deploy your API on Kubernetes or Red Hat OpenShift in less than a second. 
 
+### Run command
+```sh
+kamel run customer-api.xml \
+    --open-api customer-api.json \
+    --name customers \
+    --dependency camel-undertow \
+    --dependency camel-rest \
+    --property camel.rest.port=8080 \
+    --dev
+```
+
 ### Read the tutorial at: 
 
 https://developers.redhat.com/blog/2019/04/25/build-and-deploy-an-api-with-camel-k-on-red-hat-openshift/


### PR DESCRIPTION
The run command contains the additional `camel-rest` dependency that is needed to run the example with `kamel 1.0.0-M1` (which uses Camel 3 under the cover).